### PR TITLE
Switched git-rev-sync to use mikkoh/git-rev-sync

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "plugin:shopify/esnext",
-    "plugin:shopify/node",
-    "plugin:shopify/mocha"
+    "./node_modules/eslint-plugin-shopify/lib/config/esnext.js",
+    "./node_modules/eslint-plugin-shopify/lib/config/node.js",
+    "./node_modules/eslint-plugin-shopify/lib/config/mocha.js"
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": [
-    "./node_modules/eslint-plugin-shopify/lib/config/esnext.js",
-    "./node_modules/eslint-plugin-shopify/lib/config/node.js",
-    "./node_modules/eslint-plugin-shopify/lib/config/mocha.js"
+    "plugin:shopify/esnext",
+    "plugin:shopify/node",
+    "plugin:shopify/mocha"
   ]
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: v4.5.0
+    version: v5.7.0

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
   "author": "Shopify Inc.",
   "dependencies": {
     "git-rev-sync": "github:mikkoh/git-rev-sync#2d25f1d",
-    "minimist": "^1.2.0"
+    "minimist": "~1.2.0"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.11.4",
-    "babel-core": "^6.13.2",
-    "babel-preset-shopify": "^13.0.0",
-    "babel-register": "^6.11.6",
-    "eslint": "3.3.x",
-    "eslint-plugin-shopify": "^14.0.0",
-    "mocha": "^3.0.2"
+    "babel": "~6.5.2",
+    "babel-cli": "~6.11.4",
+    "babel-core": "~6.13.2",
+    "babel-preset-shopify": "~13.0.0",
+    "babel-register": "~6.11.6",
+    "eslint": "~3.3.0",
+    "eslint-plugin-shopify": "~14.0.2",
+    "mocha": "~3.0.2"
   },
   "scripts": {
     "test": "npm run lint-allow-warning && npm run prepublish && npm run test-cli && mocha -u tdd --compilers js:babel-register test/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {
-    "git-rev-sync": "mikkoh/git-rev-sync#2d25f1d",
+    "git-rev-sync": "mikkoh/git-rev-sync#e576ceb4992b995e208b7ae0c859305dcb2a5ebf",
     "minimist": "~1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {
-    "git-rev-sync": "github:mikkoh/git-rev-sync#2d25f1d",
+    "git-rev-sync": "mikkoh/git-rev-sync#2d25f1d",
     "minimist": "~1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {
-    "git-rev-sync": "^1.6.0",
+    "git-rev-sync": "github:mikkoh/git-rev-sync#2d25f1d",
     "minimist": "^1.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default (opts) => {
       cwd: process.cwd(),
       template: 'Version: {{version}} Commit: {{commit}}',
     },
-    opts
+    opts,
   );
 
   // Because commit and tag numbers will change for this module for testing purposes

--- a/test/test-cli-default.js
+++ b/test/test-cli-default.js
@@ -7,14 +7,8 @@ export default () => {
   test('we should get the git tag version and git commit', () => {
     const projectVersion = fs.readFileSync(path.join(__dirname, 'out-version'), 'utf8');
 
-    const tag = gitRevSync.tag();
     const commit = gitRevSync.short();
-    const regexVersion = /.*(\d+)\.(\d)+\.(\d).*/;
-    const resultVersion = regexVersion.exec(tag);
-    const major = resultVersion[1];
-    const minor = resultVersion[2];
-    const patch = resultVersion[3];
-    const version = `${major}.${minor}.${patch}`;
+    const version = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;
 
     const expected = `Version: ${version} Commit: ${commit}`;
 

--- a/test/test-cli-template.js
+++ b/test/test-cli-template.js
@@ -1,4 +1,3 @@
-import gitRevSync from 'git-rev-sync';
 import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
@@ -7,13 +6,7 @@ export default () => {
   test('we should get the git tag version and git commit', () => {
     const projectVersion = fs.readFileSync(path.join(__dirname, 'out-version-template'), 'utf8');
 
-    const tag = gitRevSync.tag();
-    const regexVersion = /.*(\d+)\.(\d)+\.(\d).*/;
-    const resultVersion = regexVersion.exec(tag);
-    const major = resultVersion[1];
-    const minor = resultVersion[2];
-    const patch = resultVersion[3];
-    const version = `${major}.${minor}.${patch}`;
+    const version = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;
 
     const expected = `${version}`;
 

--- a/test/test-modify-template.js
+++ b/test/test-modify-template.js
@@ -1,5 +1,7 @@
 import gitRevSync from 'git-rev-sync';
 import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
 
 import getProjectVersion from '../src/';
 
@@ -9,14 +11,8 @@ export default () => {
       template: '{{version}} {{commit}}',
     });
 
-    const tag = gitRevSync.tag();
     const commit = gitRevSync.short();
-    const regexVersion = /.*(\d+)\.(\d)+\.(\d).*/;
-    const resultVersion = regexVersion.exec(tag);
-    const major = resultVersion[1];
-    const minor = resultVersion[2];
-    const patch = resultVersion[3];
-    const version = `${major}.${minor}.${patch}`;
+    const version = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;
 
     const expected = `${version} ${commit}`;
 

--- a/test/test-no-opts.js
+++ b/test/test-no-opts.js
@@ -1,5 +1,7 @@
 import gitRevSync from 'git-rev-sync';
 import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
 
 import getProjectVersion from '../src/';
 
@@ -7,14 +9,8 @@ export default () => {
   test('we should get the git tag version and git commit', () => {
     const projectVersion = getProjectVersion();
 
-    const tag = gitRevSync.tag();
     const commit = gitRevSync.short();
-    const regexVersion = /.*(\d+)\.(\d)+\.(\d).*/;
-    const resultVersion = regexVersion.exec(tag);
-    const major = resultVersion[1];
-    const minor = resultVersion[2];
-    const patch = resultVersion[3];
-    const version = `${major}.${minor}.${patch}`;
+    const version = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;
 
     const expected = `Version: ${version} Commit: ${commit}`;
 


### PR DESCRIPTION
There is currently a bug which exist in https://www.npmjs.com/package/git-rev-sync

I've created a pull request which fixes this issue:
https://github.com/kurttheviking/git-rev-sync/pull/19

Temporarily though I'd like to use my fork as a dep on `get-project-version`.

Thoughts @minasmart @lreeves ?
