### PR TITLE
Implemented overriding commit hash if no commits exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ node_modules
 bundle.js
 test/output
 lib/
-test/out-version
-test/out-version-template
+test/out-*

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ console.log(version); // 1.0.0-081b152
 Options you can pass `getProjectVersion`:
 - `template` - An optional String which templates the output of `getProjectVersion`. Version will be injected into `{{version}}` and a shortened commit hash will be injected into `{{commit}}`. eg. `'{{version}}-{{commit}}'`
 - `cwd` - An optional String. By default the current working directory will be `process.cwd()` you can modify this by passing a path. eg. `'pathToProjectDir/'`
+- `noCommit` - A String which will be used instead of a commit hash if no commit hash exists. Default `"no commit"`
 
 ## CLI
 
@@ -97,6 +98,14 @@ $ get-project-version --cwd pathToProjectDir/
 ```
 
 The above would output a version string for `pathToProjectDir/`
+
+#### CLI EXample - No Commit
+
+```bash
+$ get-project-version --noCommit "0-commits"
+```
+
+The above will use `"0-commits"` for the version string instead of the default `"no commit"` if the cwd `get-project-version` is running in is not a git repo or has no commits.
 
 
 ## License

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
   },
   "scripts": {
     "test": "npm run lint-allow-warning && npm run prepublish && npm run test-cli && mocha -u tdd --compilers js:babel-register test/index.js",
-    "test-cli": "npm run test-cli-default && npm run test-cli-template",
+    "posttest": "rm test/out-version; rm test/out-version-template; rm test/out-no-commit-message",
+    "test-cli": "npm run test-cli-default && npm run test-cli-template && npm run test-cli-no-commit-message",
     "test-clean": "rm test/out-version; rm test/out-version-template",
     "test-cli-default": "node lib/cli.js > test/out-version",
     "test-cli-template": "node lib/cli.js --template '{{version}}' > test/out-version-template",
+    "test-cli-no-commit-message": "node lib/cli.js --noCommit '0-commits' --ignoreGit > test/out-no-commit-message",
     "prepublish": "babel -d lib/ src/",
     "lint": "eslint --max-warnings 0 -c .eslintrc.json src/ test/",
     "lint-allow-warning": "eslint -c .eslintrc.json src/ test/"

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export default (opts) => {
     {
       cwd: process.cwd(),
       template: 'Version: {{version}} Commit: {{commit}}',
+      noCommit: 'no commit',
     },
     opts,
   );
@@ -37,11 +38,17 @@ export default (opts) => {
   let version;
 
   try {
-    commit = options.commit || gitRevSync.short(options.cwd);
-    tag = options.tag || gitRevSync.tag(options.cwd);
-    resultVersion = regexVersion.exec(tag);
+    // this is for testing purposes to ensure that the no commit message
+    // will be used
+    if (options.ignoreGit) {
+      commit = options.noCommit;
+    } else {
+      commit = options.commit || gitRevSync.short(options.cwd);
+      tag = options.tag || gitRevSync.tag(options.cwd);
+      resultVersion = regexVersion.exec(tag);
+    }
   } catch (error) {
-    commit = 'no commit';
+    commit = options.noCommit;
   }
 
   // if git tag does not have a version number read in from package.json

--- a/test/index.js
+++ b/test/index.js
@@ -1,16 +1,20 @@
 import testCliDefault from './test-cli-default';
 import testCliTemplate from './test-cli-template';
+import testCliNoCommit from './test-cli-no-commit';
 import testModifyTemplate from './test-modify-template';
 import testNoOpts from './test-no-opts';
 import testNoTag from './test-no-tag';
+import testNoCommit from './test-no-commit';
 
-suite('test basic usage', () => {
+suite('test api', () => {
   testNoOpts();
   testModifyTemplate();
   testNoTag();
+  testNoCommit();
 });
 
 suite('test cli', () => {
   testCliDefault();
   testCliTemplate();
+  testCliNoCommit();
 });

--- a/test/test-cli-no-commit.js
+++ b/test/test-cli-no-commit.js
@@ -3,12 +3,12 @@ import fs from 'fs';
 import path from 'path';
 
 export default () => {
-  test('we should get a version string that looks different if we change the template', () => {
-    const projectVersion = fs.readFileSync(path.join(__dirname, 'out-version-template'), 'utf8');
+  test('new no commit message should be used', () => {
+    const projectVersion = fs.readFileSync(path.join(__dirname, 'out-no-commit-message'), 'utf8');
 
     const version = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;
 
-    const expected = `${version}`;
+    const expected = `Version: ${version} Commit: 0-commits`;
 
     assert.equal(projectVersion, expected, 'version string matched');
   });

--- a/test/test-no-commit.js
+++ b/test/test-no-commit.js
@@ -1,0 +1,22 @@
+import gitRevSync from 'git-rev-sync';
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+
+import getProjectVersion from '../src/';
+
+export default () => {
+  test('new no commit message should be used', () => {
+    const noCommit = '0-commmits';
+    const projectVersion = getProjectVersion({
+      noCommit,
+      ignoreGit: true,
+    });
+
+    const version = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf8')).version;
+
+    const expected = `Version: ${version} Commit: ${noCommit}`;
+
+    assert.equal(projectVersion, expected, 'version string matched');
+  });
+};


### PR DESCRIPTION
There are cases where you might want to override the commit hash if no commits exist in cwd `get-project-version` is running in. This PR adds that ability both in the API and CLI.

Could you check this PR @minasmart @harisaurus @macdonaldr93 
